### PR TITLE
Add floating point validation

### DIFF
--- a/script.js
+++ b/script.js
@@ -11,12 +11,13 @@ function Clear()
 function Eval()
 {
     let p =a.value;
+    const maxLen = p.split(/[^\d.]/).map(el => el.slice(el.indexOf(".")+1).length).sort((a, b) => a - b)[0]
     while(p.includes("^"))
     {
         p=p.replace('^',"**");
     }
     console.log(p);
-    a.value=eval(p);
+    a.value=(Math.round(eval(p) * 10 ** maxLen)) / (10 ** maxLen);
 }
 function back()
 {


### PR DESCRIPTION
This fixes #2. 

The code I've added splits the input string by operator (to get an array of the numbers), then gets the length after the decimal point for each number, and returns the longest. 

Then, it uses that to round the `eval` result to the appropriate length based on user inputs.